### PR TITLE
Feat: schedule 테이블 컬럼 이름 변경 마이그레이션 생성

### DIFF
--- a/migrations/1736684908471_rename-schedule-column.ts
+++ b/migrations/1736684908471_rename-schedule-column.ts
@@ -1,0 +1,17 @@
+import type { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+	await db.schema
+		.alterTable('schedule')
+		.renameColumn('start_at', 'start_time')
+		.renameColumn('end_at', 'end_time')
+		.execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+	await db.schema
+		.alterTable('schedule')
+		.renameColumn('start_time', 'start_at')
+		.renameColumn('end_time', 'end_at')
+		.execute();
+}


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

schedule 테이블의 `start_at`, `end_at` 컬럼을 `start_time`, `end_time` 으로 변경합니다.

### 🖥️ 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
