### PR TITLE
Fix: Windows 환경에서 swagger docs 생성되지 않는 문제 해결

### DIFF
--- a/src/config/swagger.ts
+++ b/src/config/swagger.ts
@@ -3,6 +3,7 @@ import { promises as fs } from "fs";
 import path from "path";
 import swaggerAutogen from "swagger-autogen";
 import swaggerUi from "swagger-ui-express";
+import { pathToFileURL } from "url";
 
 import logger from "@/logger";
 
@@ -59,10 +60,13 @@ const doc = {
   },
 };
 
-const outputFile = path.join(__dirname, "../../dist/swagger-output.json");
-const endpointsFiles = [path.join(__dirname, "../app.ts")];
+const outputFile = path.join(__dirname, "..", "..", "dist", "swagger-output.json");
+const endpointsFiles = ["./app.ts"];
 
-fs.mkdir(path.dirname(outputFile), { recursive: true });
+fs.mkdir(path.dirname(outputFile), { recursive: true }).catch((error) => {
+  if (error.code === "EEXIST") return;
+  logger.error(error, "Failed to create swagger-output.json directory.");
+});
 
 const generateSwagger = swaggerAutogen({ openapi: "3.1.1" })(outputFile, endpointsFiles, doc);
 
@@ -76,11 +80,11 @@ export const setupSwagger = async (app: Express): Promise<boolean> => {
 
     try {
       await fs.access(outputFile);
-      const swaggerDocument = await import(outputFile);
+      const swaggerDocument = await import(pathToFileURL(outputFile).href);
       app.use("/swagger", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
       return true;
-    } catch {
-      logger.error("swagger-output.json does not exists.");
+    } catch (error) {
+      logger.error(error, "swagger-output.json does not exists.");
       return false;
     }
   } catch (error) {


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

윈도우 환경에서 경로 관련 이슈와 swagger-autogen이 작동하지 않던 문제를 수정하였습니다.

`Windows 10`과 `Arch Linux`, `macOS Sequoia 15.1.1` 에서 작동을 확인하였습니다.

### 🖥️ 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
