### PR TITLE
Feat: 가게 생성 시 주인도 storeMember에 추가

### DIFF
--- a/migrations/1736851787737_change-primary-key.ts
+++ b/migrations/1736851787737_change-primary-key.ts
@@ -1,0 +1,23 @@
+import { type Kysely, sql } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+	
+	await db.schema
+	.alterTable("store_member")
+	.dropConstraint("store_member_user_id_fk")
+	.execute();
+	
+	await sql`ALTER TABLE store_member DROP PRIMARY KEY`.execute(db);
+	
+	await db.schema
+		.alterTable('store_member')
+		.addForeignKeyConstraint("store_member_user_id_fk", ["user_id"], "user", ["id"])
+		.execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+	await db.schema
+		.alterTable('store_member')
+		.addPrimaryKeyConstraint("store_member_pk", ["user_id"])
+		.execute();
+}

--- a/src/controllers/stores.controller.ts
+++ b/src/controllers/stores.controller.ts
@@ -17,13 +17,18 @@ export const getStores = async (_: Request, res: Response) => {
 
 /** POST /stores */
 export const createStore = async (req: Request, res: Response) => {
-  const store = await services.createStore({
+  const { result, storeId } = await services.createStore({
     ownerId: req.auth!.id,
     ...req.body,
   });
 
-  if ((store.numInsertedOrUpdatedRows ?? 0) === 0) {
+  if ((result.numInsertedOrUpdatedRows ?? 0) === 0) {
     throw new Error("Failed to add store");
+  }
+
+  const memberResult = await services.addStoreMember(storeId, req.auth!.id);
+  if (memberResult.numInsertedOrUpdatedRows === BigInt(0)) {
+    throw new Error("Failed to add store member");
   }
 
   res.status(201).json({ message: "가게가 생성되었습니다." });

--- a/src/services/stores.service.ts
+++ b/src/services/stores.service.ts
@@ -38,13 +38,14 @@ export const getStoreMembers = async (storeId: string) => {
 
 export const createStore = async (payload: CreateStorePayload) => {
   const { ownerId, title, location, contact, password, openTime, closeTime } = payload;
+  const storeId = nanoid(8);
 
-  const store = await db
+  const result = await db
     .insertInto("store")
-    .values({ id: nanoid(8), ownerId, title, location, contact, password, openTime, closeTime })
+    .values({ id: storeId, ownerId, title, location, contact, password, openTime, closeTime })
     .executeTakeFirst();
 
-  return store;
+  return { result, storeId };
 };
 
 export const addStoreMember = async (storeId: string, userId: string) => {


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

채팅방 참여자를 `store_member` 테이블에서 가져다 쓰기 때문에 가게 주인도 `store_member` 테이블에 insert 하도록 수정하였습니다.

~~스크린샷 올리면서 본건데 `user_id`가 PK 처리되어있어 이 점 수정 진행해야할 것 같습니다.~~

해결하였습니다.

![image](https://github.com/user-attachments/assets/d6b13a3a-a697-4896-9b6e-4ca3c902a58b)

### 🖥️ 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/feae5ea8-0932-4ef1-b36c-bbf8d9e235cd)

![image](https://github.com/user-attachments/assets/2844c1aa-d5af-4f9a-b214-7e0cde4def7e)

![image](https://github.com/user-attachments/assets/628ec6b1-7462-4d92-9092-651071f14388)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
