### PR TITLE
Fix: TIMESTAMP 시간대 이슈 해결

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -8,10 +8,13 @@ import logger from "@/logger";
 const dialect = new MysqlDialect({
   pool: createPool({
     uri: config.database.url,
-    dateStrings: true,
     typeCast(field, next) {
       if (field.type === "TINY" && field.length === 1) {
         return field.string() === "1";
+      }
+      if (field.type === "TIMESTAMP") {
+        const value = field.string();
+        return value ? new Date(new Date(value).getTime() + (9 * 60 * 60 * 1000)) : null;
       }
       return next();
     },

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -14,7 +14,7 @@ const dialect = new MysqlDialect({
       }
       if (field.type === "TIMESTAMP") {
         const value = field.string();
-        return value ? new Date(new Date(value).getTime() + (9 * 60 * 60 * 1000)) : null;
+        return value ? new Date(new Date(value).getTime() + 9 * 60 * 60 * 1000) : null;
       }
       return next();
     },


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

TIMESTAMP로 선언된 필드를 백엔드에서 시간대 계산을 잘못 하던 문제를 해결하였습니다.

데이터베이스의 UTC 시간대를 Kysely가 변환하면서 계산 없이 단순 KST로 변환 한 후, REST API로 리턴 해줄 때 UTC로 변환하기 위해 KST-9 계산이 들어가 잘못된 시간대가 출력된 것으로 추정하고 있습니다.

### 🖥️ 스크린샷 (선택)

#### 이전

![image](https://github.com/user-attachments/assets/079243a7-2d97-4456-847d-fc4176150ac4)

#### 이후

![image](https://github.com/user-attachments/assets/e96c5575-fe9f-4721-af4c-e490da183bde)

#### new Date()

![image](https://github.com/user-attachments/assets/dff9fb69-1243-493c-bb61-f4b68cabdb46)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
