### PR TITLE
Fix : 채팅방 조회 시 가게에서 나간 사용자일 경우 알수없는 사용자 라고 표기

### DIFF
--- a/src/controllers/chat.controller.ts
+++ b/src/controllers/chat.controller.ts
@@ -9,7 +9,7 @@ export const getChatRoomDetail = async (req: Request, res: Response) => {
   const { id } = req.params;
   const chatRoomDetail = { members: {}, messages: {} };
   const members = await services.getChatRoomMemebers(id);
-  const messages = await services.getChatRoomMessages(id);
+  const messages = await services.getChatRoomMessages(id, members);
   if (messages.length > 0) {
     const result = await services.saveLastMessage(req.auth!.id, id, messages[messages.length - 1].id);
     if (result === BigInt(0)) {

--- a/src/controllers/socket.controller.ts
+++ b/src/controllers/socket.controller.ts
@@ -123,7 +123,7 @@ const socket = (server: http.Server) => {
             const clientSocket = chatListSocket.sockets.get(socketId as string);
             clientSocket?.emit("chatLists", { data: payload });
           } else if (usersInRoomByUserId.has(notiUserId)) {
-            const socketId = usersInRoomByUserId.get(userId)!;
+            const socketId = usersInRoomByUserId.get(notiUserId)!;
             if (!roomSocketIds.includes(socketId)) {
               const clientSocket = chatRoomSocket.sockets.get(socketId as string);
               clientSocket?.emit("newMessage", { isNewMessage: true });

--- a/src/interfaces/chat.interface.ts
+++ b/src/interfaces/chat.interface.ts
@@ -11,3 +11,8 @@ export interface getChatRoom {
   memberCount?: number;
   createdAt?: Date;
 }
+
+export interface RoomMembers {
+  userId: string;
+  name: string;
+}

--- a/src/services/chat.service.ts
+++ b/src/services/chat.service.ts
@@ -2,7 +2,7 @@ import { sql } from "kysely";
 import { nanoid } from "nanoid";
 
 import { db } from "@/db";
-import { getChatRoom } from "@/interfaces/chat.interface";
+import { getChatRoom, RoomMembers } from "@/interfaces/chat.interface";
 import { dateFormat } from "@/utils/dateFormat";
 
 //채팅방 생성
@@ -94,7 +94,11 @@ export const getLastMessageAndCount = async (chatRoomId: string, userId: string)
 };
 
 // 채팅방 상세조회
-export const getChatRoomMessages = async (chatRoomId: string) => {
+export const getChatRoomMessages = async (chatRoomId: string, members: RoomMembers[]) => {
+  const userIds = [];
+  for (let i = 0; i < members.length; i++) {
+    userIds.push(members[i].userId);
+  }
   const messages = await db
     .selectFrom("message")
     .innerJoin("user", "user.id", "message.senderId")
@@ -102,6 +106,11 @@ export const getChatRoomMessages = async (chatRoomId: string) => {
     .where("roomId", "=", chatRoomId)
     .orderBy("createdAt asc")
     .execute();
+  for (let i = 0; i < messages.length; i++) {
+    if (!userIds.includes(messages[i].senderId)) {
+      messages[i].senderId = "알수없는 사용자";
+    }
+  }
   return messages;
 };
 


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 채팅방 조회시 가게에서 나간 사용자인 경우 사용자 이름을 알수없는 사용자 라고 표기했습니다.
- 소켓부분 오타 수정했습니다.

### 🖥️ 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
