### PR TITLE
Feat: Cloudflare R2 연동 제거 및 상세 교육 자료 구현

### DIFF
--- a/migrations/1738416235872_education-image.ts
+++ b/migrations/1738416235872_education-image.ts
@@ -1,0 +1,17 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("education_page")
+    .dropColumn("img")
+		.modifyColumn("content", sql`LONGTEXT`)
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("education_page")
+    .addColumn("img", "varchar(255)")
+    .modifyColumn("content", sql`TEXT`)
+    .execute();
+}

--- a/migrations/1738416235872_education-image.ts
+++ b/migrations/1738416235872_education-image.ts
@@ -4,7 +4,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
     .alterTable("education_page")
     .dropColumn("img")
-		.modifyColumn("content", sql`LONGTEXT`)
+    .modifyColumn("content", sql`LONGTEXT`)
     .execute();
 }
 

--- a/src/controllers/stores-edu.controller.ts
+++ b/src/controllers/stores-edu.controller.ts
@@ -31,7 +31,7 @@ export const getEducation = async (req: Request, res: Response) => {
   }
 
   res.status(200).json(education);
-}
+};
 
 export const createEducation = async (req: Request, res: Response) => {
   const isStoreOwner = await isOwner(req.auth!.id, req.params.storeId);

--- a/src/controllers/stores-edu.controller.ts
+++ b/src/controllers/stores-edu.controller.ts
@@ -19,6 +19,20 @@ export const getEducations = async (req: Request, res: Response) => {
   res.status(200).json(educations);
 };
 
+export const getEducation = async (req: Request, res: Response) => {
+  const isStoreMember = await services.isStoreMember(req.params.storeId, req.auth!.id);
+  if (!isStoreMember) {
+    throw new HttpException(403, "가게가 존재하지 않거나 가게에 소속되어 있지 않습니다.");
+  }
+
+  const education = await services.getEducationById(req.params.storeId, req.params.eduId);
+  if (!education) {
+    throw new HttpException(404, "강의 자료가 존재하지 않습니다.");
+  }
+
+  res.status(200).json(education);
+}
+
 export const createEducation = async (req: Request, res: Response) => {
   const isStoreOwner = await isOwner(req.auth!.id, req.params.storeId);
   if (!isStoreOwner) {
@@ -39,7 +53,7 @@ export const updateEducation = async (req: Request, res: Response) => {
     throw new HttpException(403, "가게 소유자만 수정할 수 있습니다.");
   }
 
-  const result = await services.updateEducationById(req.params.eduId, req.body);
+  const result = await services.updateEducationById(req.params.storeId, req.params.eduId, req.body);
   if (result.numUpdatedRows === BigInt(0)) {
     throw new HttpException(404, "강의 자료가 존재하지 않습니다.");
   }
@@ -53,7 +67,7 @@ export const deleteEducation = async (req: Request, res: Response) => {
     throw new HttpException(403, "가게 소유자만 삭제할 수 있습니다.");
   }
 
-  const result = await services.deleteEducationById(req.params.eduId);
+  const result = await services.deleteEducationById(req.params.storeId, req.params.eduId);
   if (result.numDeletedRows === BigInt(0)) {
     throw new HttpException(404, "강의 자료가 존재하지 않습니다.");
   }

--- a/src/controllers/stores-edu.controller.ts
+++ b/src/controllers/stores-edu.controller.ts
@@ -1,6 +1,5 @@
 import { Request, Response } from "express";
 
-import config from "@/config";
 import HttpException from "@/interfaces/http-exception.interface";
 import { isOwner } from "@/services/stores.service";
 import * as services from "@/services/stores-edu.service";
@@ -17,12 +16,7 @@ export const getEducations = async (req: Request, res: Response) => {
     return;
   }
 
-  res.status(200).json(
-    educations.map((edu) => ({
-      ...edu,
-      img: edu.img ? `https://${config.cloudflare.customDomain}/${edu.img}` : null,
-    })),
-  );
+  res.status(200).json(educations);
 };
 
 export const createEducation = async (req: Request, res: Response) => {
@@ -31,15 +25,7 @@ export const createEducation = async (req: Request, res: Response) => {
     throw new HttpException(403, "가게 소유자만 생성할 수 있습니다.");
   }
 
-  const result = await services.createEducation(
-    {
-      title: req.body.title,
-      content: req.body.content,
-      img: req.file?.buffer,
-      mimeType: req.file?.mimetype,
-    },
-    req.params.storeId,
-  );
+  const result = await services.createEducation(req.body, req.params.storeId);
   if (result.numInsertedOrUpdatedRows === BigInt(0)) {
     throw new Error("Failed to create education");
   }
@@ -53,14 +39,8 @@ export const updateEducation = async (req: Request, res: Response) => {
     throw new HttpException(403, "가게 소유자만 수정할 수 있습니다.");
   }
 
-  const result = await services.updateEducationById(req.params.eduId, {
-    title: req.body.title !== "" ? req.body.title : undefined,
-    content: req.body.content !== "" ? req.body.content : undefined,
-    img: req.file?.buffer,
-    mimeType: req.file?.mimetype,
-    deleteImg: req.body.deleteImg === "true",
-  });
-  if (!result || result.numUpdatedRows === BigInt(0)) {
+  const result = await services.updateEducationById(req.params.eduId, req.body);
+  if (result.numUpdatedRows === BigInt(0)) {
     throw new HttpException(404, "강의 자료가 존재하지 않습니다.");
   }
 
@@ -74,7 +54,7 @@ export const deleteEducation = async (req: Request, res: Response) => {
   }
 
   const result = await services.deleteEducationById(req.params.eduId);
-  if (!result || result.numDeletedRows === BigInt(0)) {
+  if (result.numDeletedRows === BigInt(0)) {
     throw new HttpException(404, "강의 자료가 존재하지 않습니다.");
   }
 

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -109,7 +109,6 @@ export interface EducationPageTable {
   storeId: string;
   title: string;
   content: string;
-  img: string | null;
   createdAt: ColumnType<Date, string | undefined, never>;
 }
 

--- a/src/interfaces/edu.interface.ts
+++ b/src/interfaces/edu.interface.ts
@@ -9,10 +9,4 @@ export interface CreateEducationPagePayload {
 export interface CreateEducationPayload {
   title: string;
   content: string;
-  img?: Buffer;
-  mimeType?: string;
-}
-
-export interface UpdateEducationPayload extends Partial<CreateEducationPayload> {
-  deleteImg: boolean;
 }

--- a/src/routes/stores-edu.route.ts
+++ b/src/routes/stores-edu.route.ts
@@ -155,6 +155,7 @@ router.put(
       content: {
         "application/json": {
           example: {
+            "title": "POS 시스템 사용법",
             "content": "POS 시스템은 ..."
           }
         }

--- a/src/routes/stores-edu.route.ts
+++ b/src/routes/stores-edu.route.ts
@@ -1,6 +1,12 @@
 import express from "express";
 
-import { createEducation, deleteEducation, getEducation, getEducations, updateEducation } from "@/controllers/stores-edu.controller";
+import {
+  createEducation,
+  deleteEducation,
+  getEducation,
+  getEducations,
+  updateEducation,
+} from "@/controllers/stores-edu.controller";
 import authMiddleware from "@/middlewares/auth.middleware";
 import validate from "@/middlewares/validate.middleware";
 import { storeIdParamsSchema } from "@/schemas/common.schema";

--- a/src/routes/stores-edu.route.ts
+++ b/src/routes/stores-edu.route.ts
@@ -1,14 +1,10 @@
 import express from "express";
-import multer from "multer";
 
-import { multerImageConfig } from "@/config/multer";
-import { createEducation, deleteEducation, getEducations, updateEducation } from "@/controllers/stores-edu.controller";
+import { createEducation, deleteEducation, getEducation, getEducations, updateEducation } from "@/controllers/stores-edu.controller";
 import authMiddleware from "@/middlewares/auth.middleware";
 import validate from "@/middlewares/validate.middleware";
 import { storeIdParamsSchema } from "@/schemas/common.schema";
 import { createEducationSchema, eduIdParamsSchema, updateEducationSchema } from "@/schemas/educations.schema";
-
-const upload = multer(multerImageConfig);
 
 const router = express.Router({ mergeParams: true });
 
@@ -29,15 +25,13 @@ router.get(
             {
               "id": "984u-jMksANg",
               "title": "폐기 상품 처리 방법",
-              "content": "",
-              "img": null,
+              "content": "폐기 상품은 ...",
               "createdAt": "2025-01-29T18:20:00.000Z"
             },
             {
               "id": "corNml9ckz7d",
               "title": "POS 시스템 사용법",
-              "content": "",
-              "img": "https://example.com/corNml9ckz7d.png",
+              "content": "POS 시스템은 ...",
               "createdAt": "2025-01-29T18:20:25.000Z"
             },
           ]
@@ -75,23 +69,12 @@ router.post(
     #swagger.requestBody = {
       required: true,
       content: {
-        "multipart/form-data": {
-          schema: {
-            type: "object",
-            properties: {
-              title: {
-                type: "string",
-                example: "제목"
-              },
-              content: {
-                type: "string",
-                example: "내용"
-              },
-              img: { type: "string", format: "binary" },
-            },
-            required: ["title", "content"]
+        "application/json": {
+          example: {
+            "title": "POS 시스템 사용법",
+            "content": "POS 시스템은 ..."
           }
-        },
+        }
       }
     }
     #swagger.responses[201] = {
@@ -113,10 +96,51 @@ router.post(
       }
     }
   */
-  validate(storeIdParamsSchema),
-  upload.single("img"),
-  validate(createEducationSchema),
+  validate(storeIdParamsSchema.merge(createEducationSchema)),
   createEducation,
+);
+
+router.get(
+  "/:eduId",
+  /*
+    #swagger.tags = ["Education"]
+    #swagger.description = "특정 가게의 교육 자료 목록을 조회합니다."
+    #swagger.security = [{ bearerAuth: [] }]
+    #swagger.parameters['$ref'] = ['#/components/parameters/storeId', '#/components/parameters/eduId']
+    #swagger.responses[200] = {
+      description: "OK",
+      content: {
+        "application/json": {
+          example: {
+            "id": "corNml9ckz7d",
+            "title": "POS 시스템 사용법",
+            "content": "POS 시스템은 ...",
+            "createdAt": "2025-01-29T18:20:25.000Z"
+          },
+        }
+      }
+    }
+    #swagger.responses[403] = {
+      description: "가게가 존재하지 않거나 가게에 소속되어 있지 않을 때",
+      content: {
+        "application/json": {
+          example: { message: "가게가 존재하지 않거나 가게에 소속되어 있지 않습니다." }
+        }
+      }
+    }
+    #swagger.responses[404] = {
+      description: "강의 자료가 존재하지 않을 때",
+      content: {
+        "application/json": {
+          example: {
+            "message": "존재하지 않는 강의 자료입니다."
+          }
+        }
+      }
+    }
+  */
+  validate(storeIdParamsSchema),
+  getEducation,
 );
 
 router.put(
@@ -129,26 +153,11 @@ router.put(
     #swagger.requestBody = {
       required: true,
       content: {
-        "multipart/form-data": {
-          schema: {
-            type: "object",
-            properties: {
-              title: {
-                type: "string",
-                example: ""
-              },
-              content: {
-                type: "string",
-                example: ""
-              },
-              deleteImg: {
-                type: "boolean",
-                example: false
-              },
-              img: { type: "string", format: "binary" },
-            },
+        "application/json": {
+          example: {
+            "content": "POS 시스템은 ..."
           }
-        },
+        }
       }
     }
     #swagger.responses[200] = {
@@ -170,9 +179,7 @@ router.put(
       }
     }
   */
-  validate(storeIdParamsSchema),
-  upload.single("img"),
-  validate(updateEducationSchema),
+  validate(storeIdParamsSchema.merge(updateEducationSchema)),
   updateEducation,
 );
 

--- a/src/schemas/educations.schema.ts
+++ b/src/schemas/educations.schema.ts
@@ -13,4 +13,9 @@ export const createEducationSchema = z.object({
   }),
 });
 
-export const updateEducationSchema = createEducationSchema.partial();
+export const updateEducationSchema = z.object({
+  body: z.object({
+    title: z.string().optional(),
+    content: z.string().optional(),
+  }),
+});

--- a/src/schemas/educations.schema.ts
+++ b/src/schemas/educations.schema.ts
@@ -11,19 +11,6 @@ export const createEducationSchema = z.object({
     title: z.string(),
     content: z.string(),
   }),
-  file: z
-    .object({
-      img: z
-        .custom<Express.Multer.File>()
-        .refine((file) => file.size <= 1024 * 1024 * 5, "파일 크기는 5MB 이하여야 합니다.")
-        .refine(
-          (file) => ["image/jpeg", "image/png", "image/webp"].includes(file.mimetype),
-          "지원되는 이미지 형식은 jpg, png, webp입니다.",
-        ),
-    })
-    .optional(),
 });
 
-export const updateEducationSchema = createEducationSchema
-  .partial()
-  .merge(z.object({ body: z.object({ deleteImg: z.string().optional() }) }));
+export const updateEducationSchema = createEducationSchema.partial();

--- a/src/services/stores-edu.service.ts
+++ b/src/services/stores-edu.service.ts
@@ -14,11 +14,7 @@ export const isStoreMember = async (storeId: string, userId: string) => {
 };
 
 export const getEducationsById = async (storeId: string) => {
-  return db
-    .selectFrom("educationPage")
-    .select(["id", "title", "createdAt"])
-    .where("storeId", "=", storeId)
-    .execute();
+  return db.selectFrom("educationPage").select(["id", "title", "createdAt"]).where("storeId", "=", storeId).execute();
 };
 
 export const createEducation = async (payload: CreateEducationPayload, storeId: string) => {
@@ -32,16 +28,26 @@ export const createEducation = async (payload: CreateEducationPayload, storeId: 
     .executeTakeFirst();
 };
 
-export const updateEducationById = async (eduId: string, payload: Partial<CreateEducationPayload>) => {
+export const updateEducationById = async (storeId: string, eduId: string, payload: Partial<CreateEducationPayload>) => {
   return db
     .updateTable("educationPage")
     .set({
-      ...payload
+      ...payload,
     })
     .where("id", "=", eduId)
+    .where("storeId", "=", storeId)
     .executeTakeFirst();
 };
 
-export const deleteEducationById = async (eduId: string) => {
-  return await db.deleteFrom("educationPage").where("id", "=", eduId).executeTakeFirst();
+export const deleteEducationById = async (storeId: string, eduId: string) => {
+  return await db.deleteFrom("educationPage").where("id", "=", eduId).where("storeId", "=", storeId).executeTakeFirst();
+};
+
+export const getEducationById = async (storeId: string, eduId: string) => {
+  return db
+    .selectFrom("educationPage")
+    .select(["id", "title", "content", "createdAt"])
+    .where("id", "=", eduId)
+    .where("storeId", "=", storeId)
+    .executeTakeFirst();
 };

--- a/src/services/stores-edu.service.ts
+++ b/src/services/stores-edu.service.ts
@@ -16,7 +16,7 @@ export const isStoreMember = async (storeId: string, userId: string) => {
 export const getEducationsById = async (storeId: string) => {
   return db
     .selectFrom("educationPage")
-    .select(["id", "title", "content", "img", "createdAt"])
+    .select(["id", "title", "createdAt"])
     .where("storeId", "=", storeId)
     .execute();
 };


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- Cloudflare R2 연동을 제거하였습니다
- DB에 이미지를 `base64` 타입으로 저장하기에 `content` 타입을 `TEXT` 에서 `LONGTEXT` 로 변경하였습니다.
- 전체 교육 자료에는 `content` 를 리턴하지 않으며, 특정 교육 자료를 가져올 때만 리턴하게 변경하였습니다.

### 🖥️ 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
