### PR TITLE
Fix : 채팅방 페이징 시, 처음 입장했을 때 가장 최근의 메시지를 기준으로 페이징

### DIFF
--- a/src/controllers/chat.controller.ts
+++ b/src/controllers/chat.controller.ts
@@ -8,9 +8,10 @@ import * as services from "@/services/chat.service";
 export const getChatRoomDetail = async (req: Request, res: Response) => {
   const { id } = req.params;
   const page = req.query.page as string;
+  const messageId = req.query.messageId as string;
   const chatRoomDetail = { members: {}, messages: {} };
   const members = await services.getChatRoomMemebers(id);
-  const messages = await services.getChatRoomMessages(id, members, page);
+  const messages = await services.getChatRoomMessages(id, members, page, messageId);
   if (messages.length > 0) {
     const result = await services.saveLastMessage(req.auth!.id, id, messages[messages.length - 1].id);
     if (result === BigInt(0)) {

--- a/src/controllers/chat.controller.ts
+++ b/src/controllers/chat.controller.ts
@@ -25,17 +25,3 @@ export const getChatRoomDetail = async (req: Request, res: Response) => {
   });
 };
 
-export const setLastMessage = async (req: Request, res: Response) => {
-  const body = req.body;
-  const userId = req.auth!.id;
-  const result = await services.saveLastMessage(userId, body.chatRoomId, body.messageId);
-  if (result === BigInt(0)) {
-    res.status(500).json({
-      message: "Internal Server Error.",
-    });
-    return;
-  }
-  res.status(201).json({
-    message: "채팅방 생성이 완료 됐습니다.",
-  });
-};

--- a/src/controllers/chat.controller.ts
+++ b/src/controllers/chat.controller.ts
@@ -24,4 +24,3 @@ export const getChatRoomDetail = async (req: Request, res: Response) => {
     chatRoomDetail,
   });
 };
-

--- a/src/routes/chat.route.ts
+++ b/src/routes/chat.route.ts
@@ -1,47 +1,8 @@
 import express from "express";
 
-import { getChatRoomDetail, setLastMessage } from "@/controllers/chat.controller";
+import { getChatRoomDetail } from "@/controllers/chat.controller";
 import authMiddleware from "@/middlewares/auth.middleware";
 const router = express.Router();
-
-router.put(
-  "/message/last",
-  // #swagger.tags = ["Chat"]
-  // #swagger.description = "마지막으로 읽은 메시지 설정."
-  // #swagger.security = [{ bearerAuth: [] }]
-  /*
-      #swagger.requestBody = {
-      required: true,
-      content: {
-          "application/json": {
-          schema: {
-              $ref: "#/components/schemas/saveLastMessage"
-          }  
-          }
-      }
-      }
-  */
-  /*
-      #swagger.responses[201] = {
-      description: "Created",
-      content: {
-          "application/json": {
-          example: { message: "마지막 메시지가 변경 됐습니다." }
-          }
-      }
-      }
-      #swagger.responses[500] = {
-      description: "Internal Server Error",
-      content: {
-          "application/json": {
-          example: { message: "Internal server error" }
-          }
-      }
-      }
-  */
-  authMiddleware,
-  setLastMessage,
-);
 
 //채팅방 상세 조회
 router.get(

--- a/src/services/chat.service.ts
+++ b/src/services/chat.service.ts
@@ -95,21 +95,33 @@ export const getLastMessageAndCount = async (chatRoomId: string, userId: string)
 };
 
 // 채팅방 상세조회
-export const getChatRoomMessages = async (chatRoomId: string, members: RoomMembers[], page: string) => {
+export const getChatRoomMessages = async (
+  chatRoomId: string,
+  members: RoomMembers[],
+  page: string,
+  messageId: string,
+) => {
   const userIds = [];
   const limit = 50;
-
+  let messageMark;
+  let createdAt: string;
+  if (messageId) {
+    messageMark = await db.selectFrom("message").select("createdAt").where("id", "=", messageId).executeTakeFirst();
+    createdAt = messageMark.createdAt.toISOString();
+  }
   if (!page) page = "1";
   const numPage = parseInt(page);
   const offset = (numPage - 1) * limit;
   for (let i = 0; i < members.length; i++) {
     userIds.push(members[i].userId);
   }
+
   const messages = await db
     .selectFrom("message")
     .innerJoin("user", "user.id", "message.senderId")
     .select(["content", "user.name", "senderId", "createdAt", "message.id"])
     .where("roomId", "=", chatRoomId)
+    .$if(messageId, (qb) => qb.where("createdAt", ">", createdAt))
     .orderBy("createdAt desc")
     .limit(limit)
     .offset(offset)

--- a/src/services/chat.service.ts
+++ b/src/services/chat.service.ts
@@ -104,7 +104,7 @@ export const getChatRoomMessages = async (
   const userIds = [];
   const limit = 50;
   let messageMark;
-  let createdAt: string;
+  let createdAt : unknown;
   if (messageId) {
     messageMark = await db.selectFrom("message").select("createdAt").where("id", "=", messageId).executeTakeFirst();
     createdAt = messageMark.createdAt.toISOString();
@@ -121,7 +121,7 @@ export const getChatRoomMessages = async (
     .innerJoin("user", "user.id", "message.senderId")
     .select(["content", "user.name", "senderId", "createdAt", "message.id"])
     .where("roomId", "=", chatRoomId)
-    .$if(messageId, (qb) => qb.where("createdAt", ">", createdAt))
+    .$if(messageId, (qb) => qb.where("createdAt", ">", createdAt as Date))
     .orderBy("createdAt desc")
     .limit(limit)
     .offset(offset)

--- a/src/services/chat.service.ts
+++ b/src/services/chat.service.ts
@@ -107,7 +107,7 @@ export const getChatRoomMessages = async (
   let createdAt : unknown;
   if (messageId) {
     messageMark = await db.selectFrom("message").select("createdAt").where("id", "=", messageId).executeTakeFirst();
-    createdAt = messageMark.createdAt.toISOString();
+    createdAt = messageMark!.createdAt.toISOString();
   }
   if (!page) page = "1";
   const numPage = parseInt(page);
@@ -121,7 +121,7 @@ export const getChatRoomMessages = async (
     .innerJoin("user", "user.id", "message.senderId")
     .select(["content", "user.name", "senderId", "createdAt", "message.id"])
     .where("roomId", "=", chatRoomId)
-    .$if(messageId, (qb) => qb.where("createdAt", ">", createdAt as Date))
+    .$if(messageId !== undefined, (qb) => qb.where("createdAt", ">", createdAt as Date))
     .orderBy("createdAt desc")
     .limit(limit)
     .offset(offset)

--- a/src/services/chat.service.ts
+++ b/src/services/chat.service.ts
@@ -104,7 +104,7 @@ export const getChatRoomMessages = async (
   const userIds = [];
   const limit = 50;
   let messageMark;
-  let createdAt : unknown;
+  let createdAt: unknown;
   if (messageId) {
     messageMark = await db.selectFrom("message").select("createdAt").where("id", "=", messageId).executeTakeFirst();
     createdAt = messageMark!.createdAt.toISOString();


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

채팅방 페이징 시, 처음 입장했을 때 가장 최근의 메시지를 기준으로 페이징 하도록 비즈니스 로직 수정했습니다.
필요없는 API 삭제했습니다.

### 🖥️ 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
