### PR TITLE
Fix : 메시지 페이징 시 부등호 방향 수정

### DIFF
--- a/src/services/chat.service.ts
+++ b/src/services/chat.service.ts
@@ -117,7 +117,7 @@ export const getChatRoomMessages = async (
     .innerJoin("user", "user.id", "message.senderId")
     .select(["content", "user.name", "senderId", "createdAt", "message.id"])
     .where("roomId", "=", chatRoomId)
-    .$if(messageId !== undefined, (qb) => qb.where("createdAt", ">=", createdAt as Date))
+    .$if(messageId !== undefined, (qb) => qb.where("createdAt", "<=", createdAt as Date))
     .orderBy("createdAt desc")
     .limit(limit)
     .offset(offset)


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

페이징 시 기준 메시지 보다 생성시점이 작은 메시지들을 가져오게끔 쿼리문 부등호 방향 수 정했습니다.

### 🖥️ 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
